### PR TITLE
feat:  allow agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Zextras/nbm

--- a/src/launcher/zmmailboxdmgr.c
+++ b/src/launcher/zmmailboxdmgr.c
@@ -108,7 +108,6 @@ static const char *DisallowedJVMArgs[] = {
     "-agentlib",
     "-agentpath",
     "-classpath",
-    "-javaagent",
 };
 #endif
 


### PR DESCRIPTION
This change allows passing a java agent to the mailbox.
For example we can:
- expose jxm metrics in Prometheus format using https://github.com/prometheus/jmx_exporter
- send opentracing metrics with https://github.com/open-telemetry/opentelemetry-java-instrumentation